### PR TITLE
Update to Julia v0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3 0.5
+julia 0.4
 HttpServer

--- a/src/Meddle.jl
+++ b/src/Meddle.jl
@@ -2,12 +2,12 @@
 #
 # Use the `middleware` function to build a `MidwareStack` of `Midware`.
 # Pass the `MidwareStack`, plus `req::MeddleRequest, res::Response` to `handle` to
-# run process the `req` through your `MidwareStack`.  
+# run process the `req` through your `MidwareStack`.
 #
 # Build `Midware` with functions that accept `req::MeddleRequest, res::Response`.
 # `Midware` should put any data it wants to pass in the `req.state` Dict.
-# 
-# - Return `req, res` from your `Midware` to pass control to the next piece of 
+#
+# - Return `req, res` from your `Midware` to pass control to the next piece of
 #   `Midware` in the stack.
 # - Use `respond(req, res)` to short-circut the stack and return to the client.
 #
@@ -17,12 +17,12 @@
 #     using Meddle
 #
 #     stack = middleware(DefaultHeaders,
-#                        CookieDecoder, 
-#                        FileServer(pwd()), 
-#                        NotFound)    
+#                        CookieDecoder,
+#                        FileServer(pwd()),
+#                        NotFound)
 #
 #     http = HttpHandler((req, res) -> Meddle.handle(stack, req, res))
-#    
+#
 #     server = Server(http)
 #     run(server, 8000)
 #
@@ -38,11 +38,11 @@ export Midware,
        URLDecoder,
        CookieDecoder,
        BodyDecoder,
-       FileServer, 
-       NotFound, 
-       MidwareStack, 
-       handle, 
-       middleware, 
+       FileServer,
+       NotFound,
+       MidwareStack,
+       handle,
+       middleware,
        respond
 
 immutable MeddleRequest
@@ -79,9 +79,9 @@ end
 # URLDecoder
 #
 # Decodes the URI encoding of req.resource.
-# Turns the req.state[:url_query] "foo=hello%20world&bar=fun" 
+# Turns the req.state[:url_query] "foo=hello%20world&bar=fun"
 # into req.state[:url_params] # => ["foo" => "hello world", "bar" => "fun"]
-# 
+#
 # Should be pretty far forward in the stack, makes URLs and URL strings usable.
 #
 URLDecoder = Midware() do req::MeddleRequest, res::Response
@@ -96,7 +96,7 @@ end
 
 # `CookieDecoder` builds `req.state[:cookies]` from `req.headers`.
 #
-# `req.state[:cookies]` will be a dictionary of Symbols to Strings.
+# `req.state[:cookies]` will be a dictionary of Symbols to AbstractStrings.
 # This should come fairly early in your stack,
 # before anything that needs to use cookies.
 #
@@ -114,7 +114,7 @@ end
 
 # `BodyDecoder` builds `req.state[:data]` from `req.data`.
 #
-# `req.state[:data]` will be a dictionary of Symbols to Strings.
+# `req.state[:data]` will be a dictionary of Symbols to AbstractStrings.
 # This should come fairly early in your stack,
 # before anything that needs to use POST data.
 #
@@ -127,14 +127,14 @@ end
 
 # `FileServer` returns a `Midware` to serve files in `root`
 #
-# Checks for files that match `req.resource` relative to `root` directory.  
+# Checks for files that match `req.resource` relative to `root` directory.
 # If no such file exists, then it passes to the next in the stack.
 # If a file is found, it short-circuts and responds.
 #
 
-path_in_dir(p::String, d::String) = length(p) > length(d) && p[1:length(d)] == d
+path_in_dir(p::AbstractString, d::AbstractString) = length(p) > length(d) && p[1:length(d)] == d
 
-function FileServer(root::String)
+function FileServer(root::AbstractString)
     Midware() do req::MeddleRequest, res::Response
         m = match(r"^/+(.*)$", req.state[:resource])
         if m != nothing
@@ -152,7 +152,7 @@ function FileServer(root::String)
     end
 end
 
-# `NotFound` always responds with a `404` error. 
+# `NotFound` always responds with a `404` error.
 #
 # This is useful as the last thing in your stack
 # to handle all the "no idea what to do" requests.


### PR DESCRIPTION
This PR updates Meddle to Julia v0.4 by changing the corresponding REQUIRE declaration and fixing deprecated syntax (`String` --> `AbstractString`).

My only motivation for reviving this package is that I'd like to use Morsel, which depends on Meddle (I'm planning on submitting a similar PR to Morsel soon). If folks think it's a better idea to keep this package deprecated, and remove Morsel's Meddle dependency (either by using a different middleware package or implementing a middleware layer in Morsel), I'd also be fine with that.

If this PR is approved, I'd be willing to follow up with subsequent PR(s) for adding tests. I'd also be willing to take a crack at fixing any issues/bugs that may arise.